### PR TITLE
take mapped base at dbSNP sites into account

### DIFF
--- a/src/QCStats.cpp
+++ b/src/QCStats.cpp
@@ -633,7 +633,7 @@ void QCStats::UpdateStats(SamRecord & sam, QSamFlag &filter, double minMapQualit
       depthTotalVsGC[GC->gcCount[refpos]]++;
 
     (*genomePosCovered)[refpos]=true;
-
+    if(refBase!='N') totalMappedBases++;
     // Excluding dbSNPs for mismatch rate calculation
     if((*dbSNP).size()>0 && (*dbSNP)[refpos]==true) continue;
 
@@ -653,7 +653,7 @@ void QCStats::UpdateStats(SamRecord & sam, QSamFlag &filter, double minMapQualit
 
     // Maped based
     //if(refBase=='A' || refBase=='C' || refBase=='G' || refBase=='T') totalMappedBases++;
-    if(refBase!='N') totalMappedBases++;
+//    if(refBase!='N') totalMappedBases++;
     //
     // Base compostion
     //


### PR DESCRIPTION
I found out that qplot will tend to underestimate coverage(mean depth), which results in inflated NormalizedDepth in GC plot.
To confirm this, one can sum up the (siteCount * normalizedDepth) in each GC percentatage, and then divided by total siteCount. The expected value should 1, but it seems always to be greater than 1(rearrange the code like this commit could correct this).
From the perspective of the code logic, it also makes much more sense to record mapped base along with covered region indicator rather than skip counting at dbSNP sites. 
How do you think about it?
@zhanxw 